### PR TITLE
add attribute to set greatest visible digit

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Add the CountDownClock in your layout
             flipTimer:digitTopDrawable="@drawable/background_top"
             flipTimer:digitWidth="28dp"
             flipTimer:halfDigitHeight="22dp"
+            flipTimer:greatestVisibleDigit="day"
             flipTimer:resetSymbol="8"
             flipTimer:splitterPadding="0dp"
     />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -27,6 +27,7 @@
             flipTimer:digitTopDrawable="@drawable/background_top"
             flipTimer:digitWidth="28dp"
             flipTimer:halfDigitHeight="22dp"
+            flipTimer:greatestVisibleDigit="day"
             flipTimer:resetSymbol="8"
             flipTimer:splitterPadding="0dp"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/fliptimerviewlibrary/src/main/java/com/asp/fliptimerviewlibrary/CountdownClock.kt
+++ b/fliptimerviewlibrary/src/main/java/com/asp/fliptimerviewlibrary/CountdownClock.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.widget.LinearLayout
 import kotlinx.android.synthetic.main.view_countdown_clock_digit.view.*
 import kotlinx.android.synthetic.main.view_simple_clock.view.*
+import java.lang.IllegalArgumentException
 import java.util.concurrent.TimeUnit
 
 
@@ -69,6 +70,9 @@ class CountDownClock : LinearLayout {
 
             val countdownTickInterval = typedArray?.getInt(R.styleable.CountDownClock_countdownTickInterval, 1000)
             this.countdownTickInterval = countdownTickInterval ?: 1000
+
+            val greatestVisibleDigit = typedArray?.getInteger(R.styleable.CountDownClock_greatestVisibleDigit, 0)
+            setGreatestVisibleDigit(greatestVisibleDigit ?: 0)
 
             invalidate()
             typedArray?.recycle()
@@ -509,5 +513,28 @@ class CountDownClock : LinearLayout {
 
     }
 
+    fun setGreatestVisibleDigit(greatestVisibleDigit: Int) {
+        when (greatestVisibleDigit) {
+            0 -> {
+                // do nothing, all digits should be visible
+            }
+            1 -> {
+                // days must be invisible
+                layoutDays.visibility = View.GONE
+            }
+            2 -> {
+                // days and hours must be invisible
+                layoutDays.visibility = View.GONE
+                layoutHours.visibility = View.GONE
+            }
+            3 -> {
+                // days, hours and minutes must be invisible
+                layoutDays.visibility = View.GONE
+                layoutHours.visibility = View.GONE
+                layoutMinutes.visibility = View.GONE
+            }
+            else -> throw IllegalArgumentException("greatestVisibleDigit should be one of {0,1,2,3} but is: $greatestVisibleDigit")
+        }
+    }
 
 }

--- a/fliptimerviewlibrary/src/main/res/layout/view_simple_clock.xml
+++ b/fliptimerviewlibrary/src/main/res/layout/view_simple_clock.xml
@@ -10,6 +10,7 @@
 
     <RelativeLayout
         android:layout_width="wrap_content"
+        android:id="@+id/layoutDays"
         android:layout_height="wrap_content">
 
         <com.asp.fliptimerviewlibrary.CountDownDigit
@@ -44,6 +45,7 @@
 
     <RelativeLayout
             android:layout_marginStart="4dp"
+            android:id="@+id/layoutHours"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" android:layout_marginLeft="4dp">
 
@@ -78,6 +80,7 @@
 
     <RelativeLayout
             android:layout_marginStart="4dp"
+            android:id="@+id/layoutMinutes"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" android:layout_marginLeft="4dp">
 
@@ -113,6 +116,7 @@
     <RelativeLayout
             android:layout_marginStart="4dp"
             android:layout_width="wrap_content"
+            android:id="@+id/layoutSeconds"
             android:layout_height="wrap_content" android:layout_marginLeft="4dp">
 
         <com.asp.fliptimerviewlibrary.CountDownDigit

--- a/fliptimerviewlibrary/src/main/res/values/attrs.xml
+++ b/fliptimerviewlibrary/src/main/res/values/attrs.xml
@@ -20,8 +20,13 @@
         <attr name="animationDuration" format="integer"/>
         <attr name="almostFinishedCallbackTimeInSeconds" format="integer"/>
         <attr name="countdownTickInterval" format="integer"/>
+        <attr name="greatestVisibleDigit" format="enum">
+            <enum name="day" value="0"/>
+            <enum name="hour" value="1"/>
+            <enum name="minute" value="2"/>
+            <enum name="second" value="3"/>
+        </attr>
     </declare-styleable>
-
 
 
 </resources>


### PR DESCRIPTION
Currently `FlipTimerView  `is able to show timers in this format: `dd:hh:mm:ss`
By accepting this PR, `FlipTimerView `will also be able to show shorter formats: `hh:mm:ss`, `mm:ss` and `ss`